### PR TITLE
Release the network resource (e.g, -p) during checkpoint

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -995,6 +995,7 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func (container *Container) Checkpoint(opts *libcontainer.CriuOpts) error {
+	container.ReleaseNetwork()
 	return container.daemon.Checkpoint(container, opts)
 }
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -995,10 +995,14 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func (container *Container) Checkpoint(opts *libcontainer.CriuOpts) error {
+	if err := container.daemon.Checkpoint(container, opts); err != nil {
+		return err
+	}
+
 	if opts.LeaveRunning == false {
 		container.ReleaseNetwork()
 	}
-	return container.daemon.Checkpoint(container, opts)
+	return nil
 }
 
 // XXX Start() does a lot more.  Not sure if we have

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -995,7 +995,9 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func (container *Container) Checkpoint(opts *libcontainer.CriuOpts) error {
-	container.ReleaseNetwork()
+	if opts.LeaveRunning == false {
+		container.ReleaseNetwork()
+	}
 	return container.daemon.Checkpoint(container, opts)
 }
 


### PR DESCRIPTION
Restore failed if network resource not released during checkpoint,
e.g., a container with port open with -p

Signed-off-by: Hui Kang hkang.sunysb@gmail.com
