### PR TITLE
Set Checkpointed state to true in config file after checkpoint

### DIFF
--- a/daemon/checkpoint.go
+++ b/daemon/checkpoint.go
@@ -19,6 +19,10 @@ func (daemon *Daemon) ContainerCheckpoint(name string, opts *runconfig.CriuConfi
 		return fmt.Errorf("Cannot checkpoint container %s: %s", name, err)
 	}
 
+	if err := container.ToDisk(); err != nil {
+		return fmt.Errorf("Cannot update config for container %s: %s", name, err)
+	}
+
 	container.LogEvent("checkpoint")
 	return nil
 }


### PR DESCRIPTION
This patch updates container config file so that checkpointed state is kept
after docker daemon restarted.

Docker-DCO-1.1-Signed-off-by: Hui Kang hkang.sunysb@gmail.com (github: huikang)
