### PR TITLE
Don't give up on ENOTEMPTY error when removing containers

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"path"
+	"syscall"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
@@ -126,7 +127,21 @@ func (daemon *Daemon) cleanupContainer(container *container.Container, forceRemo
 		}
 	}()
 
-	if err = os.RemoveAll(container.Root); err != nil {
+	// Try a maximum of 10 times to remove the container's
+	// root directory.
+	// XXX This is just a workaround.  We need to find out why
+	//     os.RemoveAll() can return with an ENOTEMPTY error.
+	var i int
+	for i = 0; i < 10; i++ {
+		if err = os.RemoveAll(container.Root); err == nil {
+			break;
+		}
+		if err.(*os.PathError).Err != syscall.ENOTEMPTY {
+			return derr.ErrorCodeRmFS.WithArgs(container.ID, err)
+		}
+		logrus.Debugf(">>> Trying RemoveAll() again...\n")
+	}
+	if i == 10 {
 		return derr.ErrorCodeRmFS.WithArgs(container.ID, err)
 	}
 


### PR DESCRIPTION
When checkpointing and restoring the same container multiple times,
docker rm -f <CID> can fail with an error indicating that its root
filesystem could not be removed because it's not empty.  Turns out that
for some unknown reason, hostconfig.json is still in the directory.
This patch calls os.RemoveAll() a maximum of 10 times if it fails.

The issue may be related to the observation that hostconfig.json
is created several times when a container is started or restored.
Each time the new hostconfig.json overwrites the previous one, so at the
end there's only one hostconfig.json but it was created multiple times!

Signed-off-by: Saied Kazemi saied@google.com
