### PR TITLE
Restore network connectivity after container restore

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1028,6 +1028,9 @@ func (daemon *Daemon) Checkpoint(c *container.Container, opts *types.CriuConfig)
 func (daemon *Daemon) Restore(c *container.Container, pipes *execdriver.Pipes, restoreCallback execdriver.DriverCallback, opts *types.CriuConfig, forceRestore bool) (execdriver.ExitStatus, error) {
 	hooks := execdriver.Hooks{
 		Restore: restoreCallback,
+		PostRestore: func(processConfig *execdriver.ProcessConfig, pid int, chOOM <-chan struct{}) error {
+			return daemon.setNetworkNamespaceKey(c.ID, pid)
+		},
 	}
 
 	exitCode, err := daemon.execDriver.Restore(c.Command, pipes, hooks, opts, forceRestore)

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -40,6 +40,7 @@ type Hooks struct {
 	PostStop []DriverCallback
 	// Restore is called after the container is restored
 	Restore DriverCallback
+	PostRestore DriverCallback
 }
 
 // Info is driver specific information based on


### PR DESCRIPTION
This is a work-in-progress implementation of restoring network connectivty
after container restore.  Its main purpose is for testing and starting
a conversation for a production-quality implementation.

Signed-off-by: Saied Kazemi saied@google.com
